### PR TITLE
tweak prop.test explanation

### DIFF
--- a/inst/themes/default/prop.test.Rmd
+++ b/inst/themes/default/prop.test.Rmd
@@ -86,15 +86,15 @@ stmt3 <-
         
         paste0(
             "The observed difference in proportions is ",
-            x$estimate[2] - x$estimate[1],
+            signif(x$estimate[2] - x$estimate[1], 3),
             ". The observed proportion for the first group is ",
-            x$estimate[1],
+            signif(x$estimate[1], 3),
             " (",
             prettyNum(x1, big.mark=","), 
             " events out of a total sample size of ",
             prettyNum(n1, big.mark=","), 
             "). For the second group, the observed proportion is ",
-            x$estimate[2],
+            signif(x$estimate[2], 3),
             " (",
             prettyNum(x2, big.mark=","), 
             ", out of a total sample size of ",
@@ -125,8 +125,8 @@ stmt4 <-
     }
 ```
 
-`r stmt1`. Using a significance level of `r 1 - attr(x$conf.int, "conf")`, we `r if (x$p.value < 1 - attr(x$conf.int, "conf")) "reject" else "do not reject"` the null hypothesis, and `r stmt2`. `r stmt3`.
+`r stmt1`. Using a significance level of `r 1 - signif(attr(x$conf.int, "conf"), 3)`, we `r if (x$p.value < 1 - signif(attr(x$conf.int, "conf"), 3)) "reject" else "do not reject"` the null hypothesis, and `r stmt2`. `r stmt3`.
 
-The confidence interval for the true `r if (onesamp) "population proportion" else "difference in population proportions"` is (`r tidyx$conf.low`, `r tidyx$conf.high`). This interval will contain the true `r if(onesamp) "population proportion" else "difference in population proportions"` 95 times out of 100.
+The confidence interval for the true `r if (onesamp) "population proportion" else "difference in population proportions"` is (`r signif(tidyx$conf.low, 3)`, `r signif(tidyx$conf.high, 3)`). Intervals generated with this procedure will contain the true `r if(onesamp) "population proportion" else "difference in population proportions"` `r round(attr(x$conf.int, "conf.level") * 100)` times out of 100.
 
-The p-value for this test is `r x$p.value`. This, formally, is defined as the probability -- if the null hypothesis is true -- of observing a `r if (onesamp) "sample proportion" else "difference in sample proportions"` that is as or more extreme than the `r if (onesamp) "sample proportion" else "difference in sample proportions"` from this data set. In this case, this is the probability -- if the true `r if (onesamp) paste0("population proportion is ",  x$null.value) else "population proportions are equal"` -- of observing a `r if (onesamp) "sample proportion" else "difference in sample proportions"` that is greater than `r stmt4`.
+The p-value for this test is `r x$p.value`. In other words: if the true `r if (onesamp) "sample proportion" else "difference in sample proportions"` were exactly `r ifelse(is.null(x$null.value), 0, x$null.value)`, and we collected 100 replicate data sets, we would find a discrepancy this large (or larger) in about `r round(x$p.value * 100)` of these 100 cases.


### PR DESCRIPTION
I made a few tweaks to the explanation for `prop.test`.  These include:
- Rounding several estimated proportions to 3 significant digits
- Attempting to make the explanations for confidence intervals and especially p-values more concrete 

It's possible that I mangled the results for a corner case or two, but I think  before merging, since it's totally possible that I failed to test one or more combinations of arguments to `prop.test` and the new explanation now fails sometimes.

Here's what the output looks like for a two-sample test that the proportions are equal.

```
prop.test(c(6, 7), c(12, 12)) %>% explain()
```

This was a two-sample proportion test of the null hypothesis that the true population proportions are equal. Using a significance level of 0.05, we do not reject the null hypothesis, and cannot conclude that two population proportions are different from one another. The observed difference in proportions is 0.0833. The observed proportion for the first group is 0.5 (6 events out of a total sample size of 12). For the second group, the observed proportion is 0.583 (7, out of a total sample size of 12).

The confidence interval for the true difference in population proportions is (-0.564, 0.397). Intervals generated with this procedure will contain the true difference in population proportions 95 times out of 100.

The p-value for this test is 1. In other words: if the true difference in sample proportions were exactly 0, and we collected 100 replicate data sets, we would find a discrepancy this large (or larger) in about 100 of these 100 cases.
